### PR TITLE
add a dimension update for double border when it is re-rendered.

### DIFF
--- a/Skylab.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Skylab.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -50,8 +50,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/GoogleDataTransport.git",
       "state" : {
-        "revision" : "f6b558e3f801f2cac336b04f615ce111fa9ddaa0",
-        "version" : "9.2.1"
+        "revision" : "7874c1b48cbffd086ce8a052c4be873a78613775",
+        "version" : "9.2.3"
       }
     },
     {
@@ -59,8 +59,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/GoogleUtilities.git",
       "state" : {
-        "revision" : "0543562f85620b5b7c510c6bcbef75b562a5127b",
-        "version" : "7.11.0"
+        "revision" : "871d43135925cde39ef7421d8723ce47edfdcc39",
+        "version" : "7.11.1"
       }
     },
     {
@@ -131,8 +131,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-protobuf.git",
       "state" : {
-        "revision" : "0af9125c4eae12a4973fb66574c53a54962a9e1e",
-        "version" : "1.21.0"
+        "revision" : "f25867a208f459d3c5a06935dceb9083b11cd539",
+        "version" : "1.22.0"
       }
     },
     {

--- a/Skylab/Custom elements/DoubleBorderForView.swift
+++ b/Skylab/Custom elements/DoubleBorderForView.swift
@@ -42,12 +42,17 @@ final class DoubleBorderForView: UIView {
     }
     // This private method adds the double border to the view
     private func addDoubleBorder() {
+        // Remove previous bottomView if it exists
+        if let previousBottomView = self.viewWithTag(1001) {
+            previousBottomView.removeFromSuperview()
+        }
         // Create a new subview to hold the bottom border
         let bottomView = UIView(frame: CGRect(x: distance, y: distance, width: self.frame.width, height: self.frame.height))
         bottomView.backgroundColor = .primary
         bottomView.layer.borderWidth = borderWidth
         bottomView.layer.borderColor = borderColor.cgColor
         bottomView.layer.cornerRadius = cornerRadius
+        bottomView.tag = 1001 // Set a unique tag to identify the bottomView
         // Create a mask layer to subtract the rounded corners from the bottom view
         let maskLayer = CAShapeLayer()
         let path = UIBezierPath(rect: bottomView.bounds)


### PR DESCRIPTION
This modification uses a unique tag (1001) for the bottomView so that you can find and delete the previous version of the bottomView before creating a new one. This way, every time layoutSubviews is called, the bottomView will be updated with the correct dimensions and properties.